### PR TITLE
Rename Router -> AppRouter to fix name collision

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,9 +10,9 @@ class App extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       theme: buildLightTheme(context),
-      initialRoute: Router.splashScreen,
-      onGenerateRoute: Router.onGenerateRoute,
-      navigatorKey: Router.navigator.key,
+      initialRoute: AppRouter.splashScreen,
+      onGenerateRoute: AppRouter.onGenerateRoute,
+      navigatorKey: AppRouter.navigator.key,
     );
   }
 }

--- a/lib/routes/router.gr.dart
+++ b/lib/routes/router.gr.dart
@@ -35,7 +35,7 @@ import 'package:potbelly/screens/change_language_screen.dart';
 import 'package:potbelly/screens/edit_profile_screen.dart';
 import 'package:potbelly/screens/new_review_screen.dart';
 
-class Router {
+class AppRouter {
   static const loginScreen = '/';
   static const splashScreen = '/splash-screen';
   static const forgotPasswordScreen = '/forgot-password-screen';
@@ -66,32 +66,32 @@ class Router {
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
     final args = settings.arguments;
     switch (settings.name) {
-      case Router.loginScreen:
+      case AppRouter.loginScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => LoginScreen(),
           settings: settings,
         );
-      case Router.splashScreen:
+      case AppRouter.splashScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => SplashScreen(),
           settings: settings,
         );
-      case Router.forgotPasswordScreen:
+      case AppRouter.forgotPasswordScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => ForgotPasswordScreen(),
           settings: settings,
         );
-      case Router.registerScreen:
+      case AppRouter.registerScreen:
         return MaterialPageRoute<dynamic>(
           builder: (_) => RegisterScreen(),
           settings: settings,
         );
-      case Router.setLocationScreen:
+      case AppRouter.setLocationScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => SetLocationScreen(),
           settings: settings,
         );
-      case Router.homeScreen:
+      case AppRouter.homeScreen:
         if (hasInvalidArgs<Key>(args)) {
           return misTypedArgsRoute<Key>(args);
         }
@@ -100,7 +100,7 @@ class Router {
           builder: (_) => HomeScreen(key: typedArgs),
           settings: settings,
         );
-      case Router.rootScreen:
+      case AppRouter.rootScreen:
         if (hasInvalidArgs<CurrentScreen>(args)) {
           return misTypedArgsRoute<CurrentScreen>(args);
         }
@@ -109,7 +109,7 @@ class Router {
           builder: (_) => RootScreen(currentScreen: typedArgs),
           settings: settings,
         );
-      case Router.profileScreen:
+      case AppRouter.profileScreen:
         if (hasInvalidArgs<Key>(args)) {
           return misTypedArgsRoute<Key>(args);
         }
@@ -118,7 +118,7 @@ class Router {
           builder: (_) => ProfileScreen(key: typedArgs),
           settings: settings,
         );
-      case Router.notificationsScreen:
+      case AppRouter.notificationsScreen:
         if (hasInvalidArgs<Key>(args)) {
           return misTypedArgsRoute<Key>(args);
         }
@@ -127,12 +127,12 @@ class Router {
           builder: (_) => NotificationsScreen(key: typedArgs),
           settings: settings,
         );
-      case Router.trendingRestaurantsScreen:
+      case AppRouter.trendingRestaurantsScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => TrendingRestaurantsScreen(),
           settings: settings,
         );
-      case Router.restaurantDetailsScreen:
+      case AppRouter.restaurantDetailsScreen:
         if (hasInvalidArgs<RestaurantDetails>(args, isRequired: true)) {
           return misTypedArgsRoute<RestaurantDetails>(args);
         }
@@ -141,17 +141,17 @@ class Router {
           builder: (_) => RestaurantDetailsScreen(restaurantDetails: typedArgs),
           settings: settings,
         );
-      case Router.bookmarksScreen:
+      case AppRouter.bookmarksScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => BookmarksScreen(),
           settings: settings,
         );
-      case Router.filterScreen:
+      case AppRouter.filterScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => FilterScreen(),
           settings: settings,
         );
-      case Router.searchResultsScreen:
+      case AppRouter.searchResultsScreen:
         if (hasInvalidArgs<SearchValue>(args)) {
           return misTypedArgsRoute<SearchValue>(args);
         }
@@ -160,32 +160,32 @@ class Router {
           builder: (_) => SearchResultsScreen(typedArgs),
           settings: settings,
         );
-      case Router.reviewRatingScreen:
+      case AppRouter.reviewRatingScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => ReviewRatingScreen(),
           settings: settings,
         );
-      case Router.addRatingsScreen:
+      case AppRouter.addRatingsScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => AddRatingsScreen(),
           settings: settings,
         );
-      case Router.menuPhotosScreen:
+      case AppRouter.menuPhotosScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => MenuPhotosScreen(),
           settings: settings,
         );
-      case Router.previewMenuPhotosScreen:
+      case AppRouter.previewMenuPhotosScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => PreviewMenuPhotosScreen(),
           settings: settings,
         );
-      case Router.categoriesScreen:
+      case AppRouter.categoriesScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => CategoriesScreen(),
           settings: settings,
         );
-      case Router.categoryDetailScreen:
+      case AppRouter.categoryDetailScreen:
         if (hasInvalidArgs<CategoryDetailScreenArguments>(args,
             isRequired: true)) {
           return misTypedArgsRoute<CategoryDetailScreenArguments>(args);
@@ -200,32 +200,32 @@ class Router {
               gradient: typedArgs.gradient),
           settings: settings,
         );
-      case Router.findFriendsScreen:
+      case AppRouter.findFriendsScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => FindFriendsScreen(),
           settings: settings,
         );
-      case Router.settingsScreen:
+      case AppRouter.settingsScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => SettingsScreen(),
           settings: settings,
         );
-      case Router.changePasswordScreen:
+      case AppRouter.changePasswordScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => ChangePasswordScreen(),
           settings: settings,
         );
-      case Router.changeLanguageScreen:
+      case AppRouter.changeLanguageScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => ChangeLanguageScreen(),
           settings: settings,
         );
-      case Router.editProfileScreen:
+      case AppRouter.editProfileScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => EditProfileScreen(),
           settings: settings,
         );
-      case Router.newReviewScreen:
+      case AppRouter.newReviewScreen:
         return CupertinoPageRoute<dynamic>(
           builder: (_) => NewReviewScreen(),
           settings: settings,

--- a/lib/screens/add_ratings_screen.dart
+++ b/lib/screens/add_ratings_screen.dart
@@ -36,7 +36,7 @@ class _AddRatingsScreenState extends State<AddRatingsScreen> {
         appBar: AppBar(
           elevation: 0.0,
           leading: InkWell(
-            onTap: () => Router.navigator.pop(),
+            onTap: () => AppRouter.navigator.pop(),
             child: Image.asset(
               ImagePath.arrowBackIcon,
               color: AppColors.headingText,
@@ -53,7 +53,7 @@ class _AddRatingsScreenState extends State<AddRatingsScreen> {
           ),
           actions: <Widget>[
             InkWell(
-              onTap: () => Router.navigator.pop(),
+              onTap: () => AppRouter.navigator.pop(),
               child: Image.asset(
                 ImagePath.closeIcon,
                 color: Colors.grey,
@@ -86,7 +86,7 @@ class _AddRatingsScreenState extends State<AddRatingsScreen> {
                   alignment: Alignment.bottomCenter,
                   child: PotbellyButton(
                     'Done',
-                    onTap: () => Router.navigator.pop(),
+                    onTap: () => AppRouter.navigator.pop(),
                     buttonHeight: 65,
                     buttonWidth: MediaQuery.of(context).size.width,
                     decoration: Decorations.customHalfCurvedButtonDecoration(

--- a/lib/screens/bookmarks_screen.dart
+++ b/lib/screens/bookmarks_screen.dart
@@ -54,8 +54,8 @@ class BookmarksScreen extends StatelessWidget {
             itemBuilder: (context, index) {
               return Container(
                 child: FoodyBiteCard(
-                  onTap: () => Router.navigator.pushNamed(
-                    Router.restaurantDetailsScreen,
+                  onTap: () => AppRouter.navigator.pushNamed(
+                    AppRouter.restaurantDetailsScreen,
                     arguments: RestaurantDetails(
                       imagePath: imagePaths[index],
                       restaurantName: restaurantNames[index],

--- a/lib/screens/categories_screen.dart
+++ b/lib/screens/categories_screen.dart
@@ -19,7 +19,7 @@ class _CategoriesScreenState extends State<CategoriesScreen> {
       appBar: AppBar(
         elevation: 0.0,
         leading: InkWell(
-          onTap: () => Router.navigator.pop(),
+          onTap: () => AppRouter.navigator.pop(),
           child: Image.asset(
             ImagePath.arrowBackIcon,
             color: AppColors.headingText,
@@ -55,8 +55,8 @@ class _CategoriesScreenState extends State<CategoriesScreen> {
           itemBuilder: (context, index) {
             return Container(
               child: FoodyBiteCategoryCard(
-                onTap: () => Router.navigator.pushNamed(
-                  Router.categoryDetailScreen,
+                onTap: () => AppRouter.navigator.pushNamed(
+                  AppRouter.categoryDetailScreen,
                   arguments: CategoryDetailScreenArguments(
                     categoryName: category[index],
                     imagePath: categoryListImagePaths[index],

--- a/lib/screens/category_detail_screen.dart
+++ b/lib/screens/category_detail_screen.dart
@@ -67,7 +67,7 @@ class CategoryDetailScreen extends StatelessWidget {
                         Row(
                           children: <Widget>[
                             InkWell(
-                              onTap: () => Router.navigator.pop(),
+                              onTap: () => AppRouter.navigator.pop(),
                               child: Image.asset(ImagePath.arrowBackIcon),
                             ),
                             Spacer(flex: 1),

--- a/lib/screens/change_language_screen.dart
+++ b/lib/screens/change_language_screen.dart
@@ -36,7 +36,7 @@ class _ChangeLanguageScreenState extends State<ChangeLanguageScreen> {
           title: "Change Language",
           trailing: <Widget>[
             InkWell(
-              onTap: () => Router.navigator.pop(),
+              onTap: () => AppRouter.navigator.pop(),
               child: Center(
                 child: Container(
                   margin:

--- a/lib/screens/change_password_screen.dart
+++ b/lib/screens/change_password_screen.dart
@@ -28,7 +28,7 @@ class ChangePasswordScreen extends StatelessWidget {
             title: "Change Password",
             trailing: <Widget>[
               InkWell(
-                onTap: () => Router.navigator.pop(),
+                onTap: () => AppRouter.navigator.pop(),
                 child: Center(
                   child: Container(
                     margin:
@@ -90,8 +90,8 @@ class ChangePasswordScreen extends StatelessWidget {
               PotbellyButton(
                 "Update",
                 buttonWidth: MediaQuery.of(context).size.width,
-                onTap: () => Router.navigator.pushNamedAndRemoveUntil(
-                  Router.loginScreen,
+                onTap: () => AppRouter.navigator.pushNamedAndRemoveUntil(
+                  AppRouter.loginScreen,
                   (Route<dynamic> route) => false,
                 ),
               ),

--- a/lib/screens/edit_profile_screen.dart
+++ b/lib/screens/edit_profile_screen.dart
@@ -29,7 +29,7 @@ class EditProfileScreen extends StatelessWidget {
             title: "Edit Profile",
             trailing: <Widget>[
               InkWell(
-                onTap: () => Router.navigator.pop(),
+                onTap: () => AppRouter.navigator.pop(),
                 child: Center(
                   child: Container(
                     margin:
@@ -98,7 +98,7 @@ class EditProfileScreen extends StatelessWidget {
               PotbellyButton(
                 "Update",
                 buttonWidth: MediaQuery.of(context).size.width,
-                onTap: () => Router.navigator.pop(),
+                onTap: () => AppRouter.navigator.pop(),
               ),
               Spacer(flex: 1),
             ],

--- a/lib/screens/filter_screen.dart
+++ b/lib/screens/filter_screen.dart
@@ -165,8 +165,8 @@ class _FilterScreenState extends State<FilterScreen> {
               ),
               PotbellyButton(
                 'Apply',
-                onTap: () => Router.navigator
-                    .pushNamed(Router.trendingRestaurantsScreen),
+                onTap: () => AppRouter.navigator
+                    .pushNamed(AppRouter.trendingRestaurantsScreen),
                 buttonHeight: 65,
                 buttonWidth: (MediaQuery.of(context).size.width / 2) - 0.25,
                 decoration: Decorations.customHalfCurvedButtonDecoration(

--- a/lib/screens/forgot_password_screen.dart
+++ b/lib/screens/forgot_password_screen.dart
@@ -68,8 +68,8 @@ class ForgotPasswordScreen extends StatelessWidget {
                         child: PotbellyButton(
                           StringConst.SEND,
                           buttonWidth: widthOfScreen,
-                          onTap: () => Router.navigator
-                              .pushReplacementNamed(Router.loginScreen),
+                          onTap: () => AppRouter.navigator
+                              .pushReplacementNamed(AppRouter.loginScreen),
                         ),
                       )
                     ],
@@ -88,7 +88,7 @@ class ForgotPasswordScreen extends StatelessWidget {
       mainAxisSize: MainAxisSize.max,
       children: <Widget>[
         InkWell(
-          onTap: () => Router.navigator.pop(),
+          onTap: () => AppRouter.navigator.pop(),
           child: Padding(
             padding: const EdgeInsets.only(
               left: Sizes.MARGIN_12,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -43,22 +43,22 @@ class HomeScreen extends StatelessWidget {
                     Styles.customNormalTextStyle(color: AppColors.accentText),
                 suffixIconImagePath: ImagePath.settingsIcon,
                 borderWidth: 0.0,
-                onTapOfLeadingIcon: () => Router.navigator.pushNamed(
-                  Router.searchResultsScreen,
+                onTapOfLeadingIcon: () => AppRouter.navigator.pushNamed(
+                  AppRouter.searchResultsScreen,
                   arguments: SearchValue(
                     controller.text,
                   ),
                 ),
                 onTapOfSuffixIcon: () =>
-                    Router.navigator.pushNamed(Router.filterScreen),
+                    AppRouter.navigator.pushNamed(AppRouter.filterScreen),
                 borderStyle: BorderStyle.solid,
               ),
               SizedBox(height: 16.0),
               HeadingRow(
                 title: StringConst.TRENDING_RESTAURANTS,
                 number: StringConst.SEE_ALL_45,
-                onTapOfNumber: () => Router.navigator
-                    .pushNamed(Router.trendingRestaurantsScreen),
+                onTapOfNumber: () => AppRouter.navigator
+                    .pushNamed(AppRouter.trendingRestaurantsScreen),
               ),
               SizedBox(height: 16.0),
               Container(
@@ -71,8 +71,8 @@ class HomeScreen extends StatelessWidget {
                       return Container(
                         margin: EdgeInsets.only(right: 4.0),
                         child: FoodyBiteCard(
-                          onTap: () => Router.navigator.pushNamed(
-                            Router.restaurantDetailsScreen,
+                          onTap: () => AppRouter.navigator.pushNamed(
+                            AppRouter.restaurantDetailsScreen,
                             arguments: RestaurantDetails(
                               imagePath: imagePaths[index],
                               restaurantName: restaurantNames[index],
@@ -98,7 +98,7 @@ class HomeScreen extends StatelessWidget {
                 title: StringConst.CATEGORY,
                 number: StringConst.SEE_ALL_9,
                 onTapOfNumber: () =>
-                    Router.navigator.pushNamed(Router.categoriesScreen),
+                    AppRouter.navigator.pushNamed(AppRouter.categoriesScreen),
               ),
               SizedBox(height: 16.0),
               Container(
@@ -122,8 +122,8 @@ class HomeScreen extends StatelessWidget {
               HeadingRow(
                 title: StringConst.FRIENDS,
                 number: StringConst.SEE_ALL_56,
-                onTapOfNumber: () => Router.navigator.pushNamed(
-                  Router.findFriendsScreen,
+                onTapOfNumber: () => AppRouter.navigator.pushNamed(
+                  AppRouter.findFriendsScreen,
                 ),
               ),
               SizedBox(height: 16.0),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -89,7 +89,7 @@ class LoginScreen extends StatelessWidget {
             alignment: Alignment.topRight,
             child: InkWell(
               onTap: () =>
-                  Router.navigator.pushNamed(Router.forgotPasswordScreen),
+                  AppRouter.navigator.pushNamed(AppRouter.forgotPasswordScreen),
               child: Container(
                 margin: EdgeInsets.only(top: Sizes.MARGIN_16),
                 child: Text(
@@ -110,14 +110,14 @@ class LoginScreen extends StatelessWidget {
       children: <Widget>[
         PotbellyButton(
           StringConst.LOGIN,
-          onTap: () => Router.navigator.pushNamedAndRemoveUntil(
-            Router.rootScreen,
+          onTap: () => AppRouter.navigator.pushNamedAndRemoveUntil(
+            AppRouter.rootScreen,
             (Route<dynamic> route) => false,
           ),
         ),
         SizedBox(height: Sizes.HEIGHT_60),
         InkWell(
-          onTap: () => Router.navigator.pushNamed(Router.registerScreen),
+          onTap: () => AppRouter.navigator.pushNamed(AppRouter.registerScreen),
           child: Container(
             width: Sizes.WIDTH_150,
             height: Sizes.HEIGHT_24,

--- a/lib/screens/menu_photos_screen.dart
+++ b/lib/screens/menu_photos_screen.dart
@@ -20,7 +20,7 @@ class MenuPhotosScreen extends StatelessWidget {
       appBar: AppBar(
         elevation: 0.0,
         leading: InkWell(
-          onTap: () => Router.navigator.pop(),
+          onTap: () => AppRouter.navigator.pop(),
           child: Image.asset(
             ImagePath.arrowBackIcon,
             color: AppColors.headingText,
@@ -178,6 +178,6 @@ class MenuPhotosScreen extends StatelessWidget {
   }
 
   void navigateToPreviewPhotos(BuildContext context) {
-    Router.navigator.pushNamed(Router.previewMenuPhotosScreen);
+    AppRouter.navigator.pushNamed(AppRouter.previewMenuPhotosScreen);
   }
 }

--- a/lib/screens/new_review_screen.dart
+++ b/lib/screens/new_review_screen.dart
@@ -52,8 +52,8 @@ class _NewReviewScreenState extends State<NewReviewScreen> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
                 InkWell(
-                  onTap: () => Router.navigator.pushNamedAndRemoveUntil(
-                    Router.rootScreen, (Route<dynamic> route) => false,
+                  onTap: () => AppRouter.navigator.pushNamedAndRemoveUntil(
+                    AppRouter.rootScreen, (Route<dynamic> route) => false,
                     arguments: CurrentScreen(
                       tab_no: HomeScreen.TAB_NO,
                       currentScreen: HomeScreen(),
@@ -83,8 +83,8 @@ class _NewReviewScreenState extends State<NewReviewScreen> {
                 ),
                 InkWell(
                   onTap: () => canPost
-                      ? Router.navigator.pushNamedAndRemoveUntil(
-                    Router.rootScreen, (Route<dynamic> route) => false,
+                      ? AppRouter.navigator.pushNamedAndRemoveUntil(
+                    AppRouter.rootScreen, (Route<dynamic> route) => false,
                     arguments: CurrentScreen(
                       tab_no: HomeScreen.TAB_NO,
                       currentScreen: HomeScreen(),

--- a/lib/screens/preview_menu_photos.dart
+++ b/lib/screens/preview_menu_photos.dart
@@ -52,7 +52,7 @@ class _PreviewMenuPhotosScreenState extends State<PreviewMenuPhotosScreen> {
         backgroundColor: AppColors.kFoodyBiteDarkBackground,
         elevation: 0.0,
         leading: InkWell(
-          onTap: () => Router.navigator.pop(context),
+          onTap: () => AppRouter.navigator.pop(context),
           child: Image.asset(
             ImagePath.arrowBackIcon,
             color: AppColors.primaryColor,

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -69,14 +69,14 @@ class ProfileScreen extends StatelessWidget {
                 children: <Widget>[
                   PotbellyButton(
                     'Edit Profile',
-                    onTap: () => Router.navigator.pushNamed(Router.editProfileScreen),
+                    onTap: () => AppRouter.navigator.pushNamed(AppRouter.editProfileScreen),
                     buttonWidth: MediaQuery.of(context).size.width / 3,
                     buttonHeight: Sizes.HEIGHT_50,
                   ),
                   SpaceW16(),
                   PotbellyButton(
                     'Settings',
-                    onTap: () => Router.navigator.pushNamed(Router.settingsScreen),
+                    onTap: () => AppRouter.navigator.pushNamed(AppRouter.settingsScreen),
                     buttonWidth: MediaQuery.of(context).size.width / 3,
                     buttonHeight: Sizes.HEIGHT_50,
                     decoration: BoxDecoration(

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -49,8 +49,8 @@ class RegisterScreen extends StatelessWidget {
                       SpaceH40(),
                       PotbellyButton(
                         StringConst.REGISTER,
-                        onTap: () => Router.navigator
-                            .pushNamed(Router.setLocationScreen),
+                        onTap: () => AppRouter.navigator
+                            .pushNamed(AppRouter.setLocationScreen),
                       ),
                     SpaceH40(),
                       Row(
@@ -63,8 +63,8 @@ class RegisterScreen extends StatelessWidget {
                           ),
                           SpaceW16(),
                           InkWell(
-                            onTap: () => Router.navigator
-                                .pushReplacementNamed(Router.loginScreen),
+                            onTap: () => AppRouter.navigator
+                                .pushReplacementNamed(AppRouter.loginScreen),
                             child: Text(
                               StringConst.LOGIN,
                               textAlign: TextAlign.left,

--- a/lib/screens/restaurant_details_screen.dart
+++ b/lib/screens/restaurant_details_screen.dart
@@ -90,7 +90,7 @@ class RestaurantDetailsScreen extends StatelessWidget {
                             child: Row(
                               children: <Widget>[
                                 InkWell(
-                                  onTap: () => Router.navigator.pop(),
+                                  onTap: () => AppRouter.navigator.pop(),
                                   child: Padding(
                                     padding: const EdgeInsets.only(
                                       left: Sizes.MARGIN_16,
@@ -254,8 +254,8 @@ class RestaurantDetailsScreen extends StatelessWidget {
                           HeadingRow(
                             title: StringConst.MENU_AND_PHOTOS,
                             number: StringConst.SEE_ALL_32,
-                            onTapOfNumber: () => Router.navigator
-                                .pushNamed(Router.menuPhotosScreen),
+                            onTapOfNumber: () => AppRouter.navigator
+                                .pushNamed(AppRouter.menuPhotosScreen),
                           ),
                           SizedBox(height: 16.0),
                           Container(
@@ -283,8 +283,8 @@ class RestaurantDetailsScreen extends StatelessWidget {
                           HeadingRow(
                             title: StringConst.REVIEWS_AND_RATINGS,
                             number: StringConst.SEE_ALL_32,
-                            onTapOfNumber: () => Router.navigator
-                                .pushNamed(Router.reviewRatingScreen),
+                            onTapOfNumber: () => AppRouter.navigator
+                                .pushNamed(AppRouter.reviewRatingScreen),
                           ),
                           SizedBox(height: 16.0),
                           Column(
@@ -300,7 +300,7 @@ class RestaurantDetailsScreen extends StatelessWidget {
               PotbellyButton(
                 'Rate Your Experience ',
                 onTap: () =>
-                    Router.navigator.pushNamed(Router.addRatingsScreen),
+                    AppRouter.navigator.pushNamed(AppRouter.addRatingsScreen),
                 buttonHeight: 65,
                 buttonWidth: MediaQuery.of(context).size.width,
                 decoration: Decorations.customHalfCurvedButtonDecoration(

--- a/lib/screens/review_rating_screen.dart
+++ b/lib/screens/review_rating_screen.dart
@@ -22,7 +22,7 @@ class ReviewRatingScreen extends StatelessWidget {
       appBar: AppBar(
         elevation: 0.0,
         leading: InkWell(
-          onTap: () => Router.navigator.pop(),
+          onTap: () => AppRouter.navigator.pop(),
           child: Image.asset(
             ImagePath.arrowBackIcon,
             color: AppColors.headingText,

--- a/lib/screens/search_results.dart
+++ b/lib/screens/search_results.dart
@@ -16,7 +16,7 @@ class SearchResultsScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     void navigateToDetailScreen() {
-      Router.navigator.pushNamed(Router.restaurantDetailsScreen);
+      AppRouter.navigator.pushNamed(AppRouter.restaurantDetailsScreen);
     }
 
     var controller = TextEditingController(text: searchValue.value);
@@ -55,8 +55,8 @@ class SearchResultsScreen extends StatelessWidget {
                   itemBuilder: (context, index) {
                     return Container(
                       child: FoodyBiteCard(
-                        onTap: () => Router.navigator.pushNamed(
-                          Router.restaurantDetailsScreen,
+                        onTap: () => AppRouter.navigator.pushNamed(
+                          AppRouter.restaurantDetailsScreen,
                           arguments: RestaurantDetails(
                             imagePath: imagePaths[index],
                             restaurantName: restaurantNames[index],

--- a/lib/screens/set_location_screen.dart
+++ b/lib/screens/set_location_screen.dart
@@ -83,8 +83,8 @@ class SetLocationScreen extends StatelessWidget {
                     PotbellyButton(
                       StringConst.TURN_GPS,
                       buttonWidth: widthOfScreen,
-                      onTap: () => Router.navigator.pushNamedAndRemoveUntil(
-                        Router.rootScreen,
+                      onTap: () => AppRouter.navigator.pushNamedAndRemoveUntil(
+                        AppRouter.rootScreen,
                         (Route<dynamic> route) => false,
                       ),
                     ),
@@ -101,8 +101,8 @@ class SetLocationScreen extends StatelessWidget {
 
   Widget _buildSkipButton() {
     return InkWell(
-      onTap: () => Router.navigator.pushNamedAndRemoveUntil(
-        Router.rootScreen,
+      onTap: () => AppRouter.navigator.pushNamedAndRemoveUntil(
+        AppRouter.rootScreen,
         (Route<dynamic> route) => false,
       ),
       child: Container(

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -54,12 +54,12 @@ class SettingsScreen extends StatelessWidget {
                 SettingsListTile(
                   title: "Change Password",
                   onTap: () =>
-                      Router.navigator.pushNamed(Router.changePasswordScreen),
+                      AppRouter.navigator.pushNamed(AppRouter.changePasswordScreen),
                 ),
                 SettingsListTile(
                   title: "Change Language",
                   onTap: () =>
-                      Router.navigator.pushNamed(Router.changeLanguageScreen),
+                      AppRouter.navigator.pushNamed(AppRouter.changeLanguageScreen),
                 )
               ],
             ).toList(),
@@ -195,8 +195,8 @@ class SettingsScreen extends StatelessWidget {
                     ),
                     textStyle: textTheme.button
                         .copyWith(color: AppColors.secondaryElement),
-                    onPressed: () => Router.navigator.pushNamedAndRemoveUntil(
-                      Router.loginScreen,
+                    onPressed: () => AppRouter.navigator.pushNamedAndRemoveUntil(
+                      AppRouter.loginScreen,
                       (Route<dynamic> route) => false,
                     ),
                   ),

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -56,8 +56,8 @@ class _SplashScreenState extends State<SplashScreen>
   void textControllerListener() {
     if (_textController.status == AnimationStatus.completed) {
       Future.delayed(Duration(milliseconds: 1000), () {
-        Router.navigator.pushNamedAndRemoveUntil(
-          Router.loginScreen,
+        AppRouter.navigator.pushNamedAndRemoveUntil(
+          AppRouter.loginScreen,
           (Route<dynamic> route) => false,
         );
       });

--- a/lib/screens/trending_restaurant_screen.dart
+++ b/lib/screens/trending_restaurant_screen.dart
@@ -21,7 +21,7 @@ class TrendingRestaurantsScreen extends StatelessWidget {
           appBar: AppBar(
             elevation: 0.0,
             leading: InkWell(
-              onTap: () => Router.navigator.pop(),
+              onTap: () => AppRouter.navigator.pop(),
               child: Image.asset(
                 ImagePath.arrowBackIcon,
                 color: AppColors.headingText,
@@ -66,8 +66,8 @@ class TrendingRestaurantsScreen extends StatelessWidget {
                     itemBuilder: (context, index) {
                       return Container(
                         child: FoodyBiteCard(
-                          onTap: () => Router.navigator.pushNamed(
-                            Router.restaurantDetailsScreen,
+                          onTap: () => AppRouter.navigator.pushNamed(
+                            AppRouter.restaurantDetailsScreen,
                             arguments: RestaurantDetails(
                               imagePath: imagePaths[index],
                               restaurantName: restaurantNames[index],

--- a/lib/widgets/custom_app_bar.dart
+++ b/lib/widgets/custom_app_bar.dart
@@ -53,7 +53,7 @@ class CustomAppBar extends StatelessWidget {
 
   Widget defaultLeading() {
     return InkWell(
-      onTap: () => Router.navigator.pop(),
+      onTap: () => AppRouter.navigator.pop(),
       child: Image.asset(
         ImagePath.arrowBackIcon,
         color: AppColors.headingText,


### PR DESCRIPTION
Flutter has a new class, [Router](https://api.flutter.dev/flutter/widgets/Router-class.html) that collides with the Router class